### PR TITLE
クライアントのプロキシ設定を記述

### DIFF
--- a/src/main/java/com/trustai/Trust_AI_Yui/CloudVisionApi.java
+++ b/src/main/java/com/trustai/Trust_AI_Yui/CloudVisionApi.java
@@ -8,7 +8,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.springframework.ui.Model;
 import org.springframework.web.multipart.MultipartFile;
@@ -63,9 +62,9 @@ public class CloudVisionApi {
 		StringEntity reqEntity = new StringEntity(json);
 		request.setEntity(reqEntity);
 
-		// 実行準備
-		HttpClient httpClient = null;
-		httpClient = HttpClientBuilder.create().build();
+		// 実行準備(プロキシ設定の有無確認)
+		TrustAiYuiClientProxySetting clientProxy = new TrustAiYuiClientProxySetting();
+		HttpClient httpClient = clientProxy.getClientProxy();
 
 		// 実行
 		HttpResponse response = httpClient.execute(request);

--- a/src/main/java/com/trustai/Trust_AI_Yui/TrustAiYuiClientProxySetting.java
+++ b/src/main/java/com/trustai/Trust_AI_Yui/TrustAiYuiClientProxySetting.java
@@ -1,0 +1,48 @@
+package com.trustai.Trust_AI_Yui;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+
+public class TrustAiYuiClientProxySetting {
+
+	/**
+	 * @return httpClient
+	 */
+	public HttpClient getClientProxy(){
+		
+		// システム環境変数からプロキシの設定を取得
+		// 例：　set http_proxy　=　"proxy.mycompany.co.jp:8080"
+		final String httpProxy = System.getenv("http_proxy");
+		
+		// httpClientを初期化
+		HttpClient httpClient = null;
+		
+		// プロキシの設定ありの場合
+		if(httpProxy != null) {
+			String[] proxyList = httpProxy.replaceAll("http://","").split("@");
+			String userName = proxyList[0].split(":")[0];
+			String password = proxyList[0].split(":")[1];
+			String hostName = proxyList[1].split(":")[0];
+			String portNo = proxyList[1].split(":")[1];
+			HttpHost proxy = new HttpHost(hostName, Integer.parseInt(portNo));		
+			CredentialsProvider credsProvider = new BasicCredentialsProvider();	
+			credsProvider.setCredentials(new AuthScope(proxy),new UsernamePasswordCredentials(userName, password));	
+			RequestConfig config = RequestConfig.custom().setProxy(proxy).build();
+			httpClient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).setDefaultRequestConfig(config).build();
+		// プロキシの設定なしの場合
+		}else {
+			httpClient = HttpClientBuilder.create().build();
+		}
+		
+		// HTTPクライアントの設定をReturn
+		return httpClient;
+	}
+
+}


### PR DESCRIPTION
# クライアントのプロキシ設定を記述

* プロキシ環境下でもGoogleVisionApiと通信が出来るようにHttpClientの設定を変更
  * コマンドプロンプトで環境変数 "http_proxy" を設定する(プロキシ環境の場合のみ)
    ```
     C:\> setx http_proxy "http://ユーザ名:パスワード@proxy.example.com:8080"
    ```

  * プロキシ設定クラス [TrustAiYuiClientProxySetting.java](https://github.com/projectyuiai/Trust-AI-Yui/blob/master/src/main/java/com/trustai/Trust_AI_Yui/TrustAiYuiClientProxySetting.java) を追加